### PR TITLE
コンポーネントのテストを作成してカバレッジ100%にした

### DIFF
--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -12,10 +12,11 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
         class="_menuButtonList_171v5_1"
       >
         <div
-          class="_orderButton_1n78s_1"
+          class="_menuButton_fdi0z_1"
+          data-testid="menuButton"
         >
           <div
-            class="_menu_1n78s_25"
+            class="_menu_fdi0z_1"
           >
             <span
               class=""
@@ -30,7 +31,8 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
             </span>
           </div>
           <span
-            class="_badge_1n78s_21"
+            class="_badge_fdi0z_21"
+            data-testid="badge"
           >
             0
           </span>
@@ -40,10 +42,11 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
         class="_menuButtonList_171v5_1"
       >
         <div
-          class="_orderButton_1n78s_1"
+          class="_menuButton_fdi0z_1"
+          data-testid="menuButton"
         >
           <div
-            class="_menu_1n78s_25"
+            class="_menu_fdi0z_1"
           >
             <span
               class=""
@@ -58,7 +61,8 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
             </span>
           </div>
           <span
-            class="_badge_1n78s_21"
+            class="_badge_fdi0z_21"
+            data-testid="badge"
           >
             0
           </span>
@@ -68,10 +72,11 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
         class="_menuButtonList_171v5_1"
       >
         <div
-          class="_orderButton_1n78s_1"
+          class="_menuButton_fdi0z_1"
+          data-testid="menuButton"
         >
           <div
-            class="_menu_1n78s_25"
+            class="_menu_fdi0z_1"
           >
             <span
               class=""
@@ -86,7 +91,8 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
             </span>
           </div>
           <span
-            class="_badge_1n78s_21"
+            class="_badge_fdi0z_21"
+            data-testid="badge"
           >
             0
           </span>
@@ -96,10 +102,11 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
         class="_menuButtonList_171v5_1"
       >
         <div
-          class="_orderButton_1n78s_1"
+          class="_menuButton_fdi0z_1"
+          data-testid="menuButton"
         >
           <div
-            class="_menu_1n78s_25"
+            class="_menu_fdi0z_1"
           >
             <span
               class=""
@@ -114,7 +121,8 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
             </span>
           </div>
           <span
-            class="_badge_1n78s_21"
+            class="_badge_fdi0z_21"
+            data-testid="badge"
           >
             0
           </span>
@@ -124,10 +132,11 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
         class="_menuButtonList_171v5_1"
       >
         <div
-          class="_orderButton_1n78s_1"
+          class="_menuButton_fdi0z_1"
+          data-testid="menuButton"
         >
           <div
-            class="_menu_1n78s_25"
+            class="_menu_fdi0z_1"
           >
             <span
               class=""
@@ -142,7 +151,8 @@ exports[`<App /> のスナップショットテスト > <App /> がレンダリ�
             </span>
           </div>
           <span
-            class="_badge_1n78s_21"
+            class="_badge_fdi0z_21"
+            data-testid="badge"
           >
             0
           </span>

--- a/src/components/MenuButton.module.scss
+++ b/src/components/MenuButton.module.scss
@@ -1,4 +1,4 @@
-.orderButton {
+.menuButton {
   width: 300px;
   position: relative;
   border-radius: 4px;

--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -13,12 +13,14 @@ const MenuButton = ({ menu, updateMenus }: Props) => {
   }
   return (
     <>
-      <div className={style.orderButton} onClick={onClick}>
+      <div className={style.menuButton} onClick={onClick} data-testid="menuButton">
         <div className={style.menu}>
           <span className="">{menu.name}</span>
           <span className="">{menu.price} 円</span>
         </div>
-        <span className={style.badge}>{menu.numberOfOrders}</span>
+        <span className={style.badge} data-testid="badge">
+          {menu.numberOfOrders}
+        </span>
       </div>
     </>
   )

--- a/src/components/MenuButtonList.tsx
+++ b/src/components/MenuButtonList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Menu } from '../lib/types/menu'
-import OrderButton from './MenuButton'
+import MenuButton from './MenuButton'
 import style from './MenuButtonList.module.scss'
 
 type Props = {
@@ -9,12 +9,12 @@ type Props = {
 }
 
 const MenuButtonList = ({ menus, updateMenus }: Props) => {
-  if (!menus.length) return <div>メニューデータが存在しません。</div>
+  if (!menus.length) return <div data-testid="menuNotFound">メニューデータが存在しません。</div>
   return (
     <>
       {menus.map((menu) => (
         <div className={style.menuButtonList} key={`div-${menu.id}`}>
-          <OrderButton menu={menu} key={menu.id} updateMenus={updateMenus} />
+          <MenuButton menu={menu} key={menu.id} updateMenus={updateMenus} />
         </div>
       ))}
     </>

--- a/tests/components/MenuButton.test.tsx
+++ b/tests/components/MenuButton.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { cleanup, fireEvent, render, renderHook } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import MenuButton from '../../src/components/MenuButton'
+import { useMenu } from '../../src/hooks/useMenu'
+import { menuData } from '../../src/lib/mocks/menu-data'
+
+describe('MenuButton', () => {
+  it('正しくレンダリングされること', () => {
+    const { result } = renderHook(() => useMenu(menuData))
+    const { container } = render(
+      <MenuButton menu={result.current.menus[0]} updateMenus={result.current.updateMenus} />
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+  describe('menuButtonがクリックされたとき', () => {
+    const handleClick = vi.fn()
+    beforeAll(() => {
+      const { result } = renderHook(() => useMenu(menuData))
+      render(<MenuButton menu={result.current.menus[0]} updateMenus={handleClick} />)
+      fireEvent.click(screen.getByTestId('menuButton'))
+    })
+    it('onClickが呼ばれること', () => {
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+  afterEach(() => cleanup())
+})

--- a/tests/components/MenuButtonList.test.tsx
+++ b/tests/components/MenuButtonList.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, renderHook, screen } from '@testing-library/react'
+import { useMenu } from '../../src/hooks/useMenu'
+import { menuData } from '../../src/lib/mocks/menu-data'
+import MenuButtonList from '../../src/components/MenuButtonList'
+import { Menu } from '../../src/lib/types/menu'
+
+describe('MenuButtonList', () => {
+  it('正しくレンダリングされること', () => {
+    const { result } = renderHook(() => useMenu(menuData))
+    const { container } = render(
+      <MenuButtonList menus={result.current.menus} updateMenus={result.current.updateMenus} />
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+  it('メニューがないときに「メニューデータが存在しません」と表示されること', () => {
+    const { result } = renderHook(() => useMenu(menuData))
+    const emptyMenus: Menu[] = []
+    render(<MenuButtonList menus={emptyMenus} updateMenus={result.current.updateMenus} />)
+    const menuNotFoundElement = screen.getByTestId('menuNotFound')
+    expect(menuNotFoundElement.textContent).toEqual('メニューデータが存在しません。')
+  })
+})

--- a/tests/components/__snapshots__/MenuButton.test.tsx.snap
+++ b/tests/components/__snapshots__/MenuButton.test.tsx.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1
+
+exports[`MenuButton > 正しくレンダリングされること 1`] = `
+<div
+  class="_menuButton_fdi0z_1"
+  data-testid="menuButton"
+>
+  <div
+    class="_menu_fdi0z_1"
+  >
+    <span
+      class=""
+    >
+      コーヒー
+    </span>
+    <span
+      class=""
+    >
+      480
+       円
+    </span>
+  </div>
+  <span
+    class="_badge_fdi0z_21"
+    data-testid="badge"
+  >
+    0
+  </span>
+</div>
+`;

--- a/tests/components/__snapshots__/MenuButtonList.test.tsx.snap
+++ b/tests/components/__snapshots__/MenuButtonList.test.tsx.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1
+
+exports[`MenuButtonList > 正しくレンダリングされること 1`] = `
+<div
+  class="_menuButtonList_171v5_1"
+>
+  <div
+    class="_menuButton_fdi0z_1"
+    data-testid="menuButton"
+  >
+    <div
+      class="_menu_fdi0z_1"
+    >
+      <span
+        class=""
+      >
+        コーヒー
+      </span>
+      <span
+        class=""
+      >
+        480
+         円
+      </span>
+    </div>
+    <span
+      class="_badge_fdi0z_21"
+      data-testid="badge"
+    >
+      0
+    </span>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## 課題リンク

[コンポーネントのテストを書く](https://github.com/fj-sh/track-cafe-front/projects/1#card-82520943)

## 説明

カバレッジの数値が低かったコンポーネントのテストを作って100%にした。

## 見た目

![カバレッジ](https://user-images.githubusercontent.com/60544010/170856087-780f039f-1a69-4668-b1ec-b317da1dab1c.jpg)


## その他
